### PR TITLE
feat: add BMAD task orchestrator

### DIFF
--- a/bmad-auto
+++ b/bmad-auto
@@ -1,0 +1,14 @@
+#!/usr/bin/env python
+import pathlib
+import sys
+
+# Ensure src is on the path when running from repo checkout
+repo_root = pathlib.Path(__file__).resolve().parent
+src_path = repo_root / 'src'
+if src_path.exists():
+    sys.path.insert(0, str(src_path))
+
+from bmad_auto.cli import main
+
+if __name__ == '__main__':
+    main()

--- a/src/bmad_auto/__init__.py
+++ b/src/bmad_auto/__init__.py
@@ -1,0 +1,1 @@
+"""BMAD automation CLI package."""

--- a/src/bmad_auto/__main__.py
+++ b/src/bmad_auto/__main__.py
@@ -1,0 +1,4 @@
+from .cli import main
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/src/bmad_auto/cli.py
+++ b/src/bmad_auto/cli.py
@@ -1,0 +1,31 @@
+import argparse
+from pathlib import Path
+
+from orchestrator import Pipeline
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(prog="bmad-auto", description="BMAD automation runner")
+    sub = parser.add_subparsers(dest="command")
+
+    run_p = sub.add_parser("run", help="Execute BMAD tasks pipeline")
+    run_p.add_argument(
+        "--mode",
+        choices=["automatic", "semi-automatic", "interactive"],
+        default="automatic",
+        help="Automation mode",
+    )
+
+    args = parser.parse_args()
+
+    if args.command == "run":
+        repo_root = Path(__file__).resolve().parents[2]
+        tasks_dir = repo_root / ".bmad-core" / "tasks"
+        pipeline = Pipeline(tasks_dir)
+        pipeline.run(mode=args.mode)
+    else:
+        parser.print_help()
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/src/orchestrator/__init__.py
+++ b/src/orchestrator/__init__.py
@@ -1,0 +1,4 @@
+from .registry import StepRegistry
+from .pipeline import Pipeline
+
+__all__ = ["StepRegistry", "Pipeline"]

--- a/src/orchestrator/pipeline.py
+++ b/src/orchestrator/pipeline.py
@@ -1,0 +1,60 @@
+import os
+from pathlib import Path
+from typing import List
+
+from .registry import StepRegistry
+
+
+class Pipeline:
+    """Execution pipeline for BMAD tasks."""
+
+    def __init__(self, tasks_dir: Path, registry: StepRegistry | None = None) -> None:
+        self.tasks_dir = Path(tasks_dir)
+        self.registry = registry or StepRegistry()
+        self._load_tasks()
+
+    def _load_tasks(self) -> None:
+        files: List[Path] = sorted(self.tasks_dir.glob("*.md"))
+        for path in files:
+            name = path.stem
+
+            def make_step(p: Path, n: str):
+                def step() -> None:
+                    print(f"=== Executing task: {n} ({p}) ===")
+                    try:
+                        with p.open("r", encoding="utf-8") as fh:
+                            first = fh.readline().strip()
+                            print(first)
+                    except OSError as exc:
+                        print(f"Failed to read {p}: {exc}")
+                return step
+
+            self.registry.register(name, make_step(path, name))
+
+    def run(self, mode: str = "automatic") -> None:
+        if mode == "automatic":
+            for _, step in self.registry.steps():
+                step()
+        elif mode == "semi-automatic":
+            for name, step in self.registry.steps():
+                ans = input(f"Run task '{name}'? [Y/n]: ").strip().lower()
+                if ans in ("", "y", "yes"):
+                    step()
+        elif mode == "interactive":
+            remaining = list(self.registry.steps())
+            while remaining:
+                print("Select a task to run:")
+                for i, (name, _) in enumerate(remaining, start=1):
+                    print(f"{i}. {name}")
+                print("0. Exit")
+                try:
+                    choice = int(input("Choice: "))
+                except ValueError:
+                    continue
+                if choice == 0:
+                    break
+                if 1 <= choice <= len(remaining):
+                    name, step = remaining.pop(choice - 1)
+                    step()
+        else:
+            raise ValueError(f"Unknown mode: {mode}")

--- a/src/orchestrator/registry.py
+++ b/src/orchestrator/registry.py
@@ -1,0 +1,20 @@
+from collections import OrderedDict
+from typing import Callable, Iterable, Tuple
+
+
+class StepRegistry:
+    """Registry for mapping step names to callables."""
+
+    def __init__(self) -> None:
+        self._steps: "OrderedDict[str, Callable[[], None]]" = OrderedDict()
+
+    def register(self, name: str, func: Callable[[], None]) -> None:
+        """Register a new step."""
+        self._steps[name] = func
+
+    def get(self, name: str) -> Callable[[], None]:
+        return self._steps[name]
+
+    def steps(self) -> Iterable[Tuple[str, Callable[[], None]]]:
+        """Return an iterable of registered steps in order."""
+        return self._steps.items()


### PR DESCRIPTION
## Summary
- add step registry and pipeline to orchestrate BMAD core tasks
- wire CLI `bmad-auto run` with automation modes
- bootstrap executable script for repository usage

## Testing
- `./bmad-auto run --mode automatic`


------
https://chatgpt.com/codex/tasks/task_e_68bcfb62d7ac832d90226f7901044a52