### PR TITLE
feat: validate ideas API

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "bmad_auto",
+  "version": "1.0.0",
+  "type": "module",
+  "scripts": {
+    "test": "vitest"
+  },
+  "dependencies": {
+    "zod": "^3.22.4"
+  },
+  "devDependencies": {
+    "typescript": "^5.4.0",
+    "vitest": "^0.34.4"
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["web/**/*.ts"]
+}

--- a/web/app/api/ideas/route.test.ts
+++ b/web/app/api/ideas/route.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest';
+import { POST } from './route';
+
+describe('POST /api/ideas', () => {
+  it('returns 200 for valid payload', async () => {
+    const payload = { title: 'Idea', description: 'Great', userId: 'user123' };
+    const req = new Request('http://localhost', {
+      method: 'POST',
+      body: JSON.stringify(payload),
+      headers: { 'Content-Type': 'application/json' },
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toEqual({ success: true, data: payload });
+  });
+
+  it('returns 400 with details for invalid payload', async () => {
+    const payload = { title: '', description: 123, userId: '' };
+    const req = new Request('http://localhost', {
+      method: 'POST',
+      body: JSON.stringify(payload),
+      headers: { 'Content-Type': 'application/json' },
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(Array.isArray(body.errors)).toBe(true);
+    expect(body.errors.length).toBeGreaterThan(0);
+  });
+});
+

--- a/web/app/api/ideas/route.ts
+++ b/web/app/api/ideas/route.ts
@@ -1,0 +1,42 @@
+import { z } from 'zod';
+
+const ideaSchema = z.object({
+  title: z.string().min(1, 'Title is required'),
+  description: z.string().min(1, 'Description is required'),
+  userId: z.string().min(1, 'User ID is required'),
+});
+
+export type Idea = z.infer<typeof ideaSchema>;
+
+export async function POST(req: Request): Promise<Response> {
+  try {
+    const json = await req.json();
+    const result = ideaSchema.safeParse(json);
+    if (!result.success) {
+      return new Response(
+        JSON.stringify({ errors: result.error.issues }),
+        {
+          status: 400,
+          headers: { 'Content-Type': 'application/json' },
+        },
+      );
+    }
+
+    return new Response(
+      JSON.stringify({ success: true, data: result.data }),
+      {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      },
+    );
+  } catch {
+    return new Response(
+      JSON.stringify({ errors: [{ message: 'Invalid JSON' }] }),
+      {
+        status: 400,
+        headers: { 'Content-Type': 'application/json' },
+      },
+    );
+  }
+}
+


### PR DESCRIPTION
## Summary
- validate idea submissions with zod schema
- handle validation errors with 400 responses
- cover valid/invalid submissions with unit tests

## Testing
- `npm test` *(fails: sh: 1: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bcfb615354832d8f0621d9eecd9942